### PR TITLE
feat(mrpt_sensorlib): add /diagnostics support to all sensor nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ All packages follow [REP-2003](https://ros.org/reps/rep-2003.html) regarding ROS
 <!-- md_toc github  < README.md -->
 
 # Table of Contents
+- [Diagnostics support](#diagnostics-support)
 - [`mrpt_sensor_bumblebee_stereo`](#mrpt_sensor_bumblebee_stereo)
 - [`mrpt_sensor_gnss_nmea`](#mrpt_sensor_gnss_nmea)
 - [`mrpt_sensor_gnss_novatel`](#mrpt_sensor_gnss_novatel)
@@ -29,6 +30,87 @@ All packages follow [REP-2003](https://ros.org/reps/rep-2003.html) regarding ROS
 - [`mrpt_sensor_velodyne`](#mrpt_sensor_velodyne)
 - [novatel_oem6_msgs](novatel_oem6_msgs/)
 - [Individual package build status](#individual-package-build-status)
+
+# Diagnostics support
+
+All sensor nodes in this package publish ROS 2 diagnostics to the `/diagnostics` topic via the
+[`diagnostic_updater`](https://github.com/ros/diagnostics) package. The diagnostic status tracks
+three conditions:
+
+| Status | Condition |
+|--------|-----------|
+| `WARN` | Node started but no observation has arrived yet within the startup timeout window |
+| `ERROR` | Sensor was working but no observation has been received for longer than 3× the expected period |
+| `WARN` | Observation rate is below 50% of the configured expected rate |
+| `OK` | Observations are arriving at the expected rate |
+
+Two ROS 2 parameters control the diagnostic thresholds (settable at launch or via `ros2 param set`):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `diag_startup_timeout` | `30.0` s | How long to wait for the first observation before reporting an error |
+| `diag_expected_rate` | `1.0` Hz | Expected observation rate; used for stale and rate-warning checks |
+
+The diagnostic status also reports the measured observation rate, the observation count, and the
+hardware ID (node name).
+
+## Viewing diagnostics
+
+Echo the raw topic directly:
+
+```bash
+ros2 topic echo /diagnostics
+```
+
+For a human-friendly live view, use `rqt_runtime_monitor` or the `ros2 run` equivalent:
+
+```bash
+ros2 run rqt_runtime_monitor rqt_runtime_monitor
+```
+
+## Running a diagnostic aggregator
+
+The `diagnostic_aggregator` collects and categorizes `/diagnostics` messages into
+`/diagnostics_agg`. This is required by tools such as `robot_monitor`. To launch one quickly for
+testing, install the package and create a minimal analyzers config:
+
+```bash
+sudo apt install ros-${ROS_DISTRO}-diagnostic-aggregator
+```
+
+Create a file `analyzers.yaml`:
+
+```yaml
+analyzers:
+  ros__parameters:
+    path: Sensors
+    sensors:
+      type: diagnostic_aggregator/GenericAnalyzer
+      path: Sensors
+      contains:
+        - 'Sensor status'
+```
+
+Then run the aggregator with that config:
+
+```bash
+ros2 run diagnostic_aggregator aggregator_node --ros-args \
+    --params-file analyzers.yaml
+```
+
+In a separate terminal, echo the aggregated output:
+
+```bash
+ros2 topic echo /diagnostics_agg
+```
+
+Or open `rqt_robot_monitor` for a tree view:
+
+```bash
+ros2 run rqt_robot_monitor rqt_robot_monitor
+```
+
+---
 
 # `mrpt_sensor_bumblebee_stereo`
 

--- a/mrpt_sensorlib/CMakeLists.txt
+++ b/mrpt_sensorlib/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(tf2_ros REQUIRED)
 find_package(mrpt_msgs REQUIRED)
 find_package(mrpt-ros2bridge REQUIRED)
 find_package(mrpt-hwdrivers REQUIRED)
+find_package(diagnostic_updater REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 
 message(STATUS "MRPT_VERSION: ${mrpt-hwdrivers_VERSION}")
 
@@ -62,6 +64,7 @@ target_link_libraries(${PROJECT_NAME}
   tf2_geometry_msgs::tf2_geometry_msgs
   tf2::tf2
   tf2_ros::tf2_ros
+  diagnostic_updater::diagnostic_updater
 )
 
 
@@ -75,7 +78,7 @@ target_link_libraries(${PROJECT_NAME}
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies()
+ament_export_dependencies(diagnostic_updater)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/mrpt_sensorlib/CMakeLists.txt
+++ b/mrpt_sensorlib/CMakeLists.txt
@@ -6,13 +6,10 @@ find_package(ament_cmake REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_ros REQUIRED)
 
 find_package(mrpt_msgs REQUIRED)
 find_package(mrpt-ros2bridge REQUIRED)
 find_package(mrpt-hwdrivers REQUIRED)
-find_package(diagnostic_updater REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 
 message(STATUS "MRPT_VERSION: ${mrpt-hwdrivers_VERSION}")

--- a/mrpt_sensorlib/include/mrpt_sensorlib/mrpt_sensorlib.h
+++ b/mrpt_sensorlib/include/mrpt_sensorlib/mrpt_sensorlib.h
@@ -53,6 +53,7 @@
 
 //
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <mrpt_msgs/msg/generic_observation.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -167,5 +168,17 @@ class GenericSensorNode : public rclcpp::Node
 
   void process(const mrpt::obs::CObservationGPS& o);
   void process(const mrpt::obs::CObservationIMU& o);
+
+  // ----------------- Diagnostics -----------------
+  diagnostic_updater::Updater diag_updater_{this};
+  double diag_startup_timeout_ = 30.0;  // [s] ROS 2 param
+  double diag_expected_rate_ = 1.0;  // [Hz] ROS 2 param
+
+  double stamp_node_start_ = 0;
+  double stamp_last_obs_ = 0;
+  uint64_t obs_count_ = 0;
+  double diag_obs_rate_ = 0;  // smoothed obs rate [Hz]
+
+  void diag_callback(diagnostic_updater::DiagnosticStatusWrapper& stat);
 };
 }  // namespace mrpt_sensors

--- a/mrpt_sensorlib/package.xml
+++ b/mrpt_sensorlib/package.xml
@@ -17,6 +17,8 @@
   <depend>mrpt_libhwdrivers</depend>
   <depend>mrpt_libros_bridge</depend>
 
+  <depend>diagnostic_updater</depend>
+
   <!-- <depend>rclcpp</depend> -->
   <depend>rclcpp_components</depend>
   <!-- <depend>tf2</depend> -->

--- a/mrpt_sensorlib/src/mrpt_sensorlib.cpp
+++ b/mrpt_sensorlib/src/mrpt_sensorlib.cpp
@@ -44,6 +44,8 @@
 #include <mrpt/serialization/CArchive.h>
 #include <mrpt/system/filesystem.h>
 
+#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+
 // MRPT -> ROS bridge:
 #include <mrpt/ros2bridge/gps.h>
 #include <mrpt/ros2bridge/image.h>
@@ -61,6 +63,7 @@ namespace mrpt_sensors
 GenericSensorNode::GenericSensorNode(const std::string& nodeName) : Node(nodeName)
 {
   tf_bc_ = std::make_shared<tf2_ros::TransformBroadcaster>(this);
+  stamp_node_start_ = mrpt::Clock::nowDouble();
 }
 
 GenericSensorNode::~GenericSensorNode() {}
@@ -164,7 +167,16 @@ void GenericSensorNode::init(
     publish_sensor_pose_tf_minimum_period_ =
         this->get_parameter("publish_sensor_pose_tf_minimum_period").as_double();
 
+    this->declare_parameter("diag_startup_timeout", diag_startup_timeout_);
+    diag_startup_timeout_ = this->get_parameter("diag_startup_timeout").as_double();
+
+    this->declare_parameter("diag_expected_rate", diag_expected_rate_);
+    diag_expected_rate_ = this->get_parameter("diag_expected_rate").as_double();
+
     // ----------------- End of common ROS 2 params -----------------
+
+    diag_updater_.setHardwareID(this->get_name());
+    diag_updater_.add("Sensor status", this, &GenericSensorNode::diag_callback);
 
     // For each defined sensor:
     for (const auto& section : sections)
@@ -255,6 +267,21 @@ void GenericSensorNode::run()
 
 void GenericSensorNode::process_observation(const mrpt::obs::CObservation::Ptr& o)
 {
+  const double tNow = mrpt::Clock::nowDouble();
+  if (stamp_last_obs_ > 0)
+  {
+    const double dt = tNow - stamp_last_obs_;
+    if (dt > 0)
+    {
+      // Exponential moving average of instantaneous rate
+      const double alpha = 0.1;
+      diag_obs_rate_ = (1.0 - alpha) * diag_obs_rate_ + alpha * (1.0 / dt);
+    }
+  }
+  stamp_last_obs_ = tNow;
+  obs_count_++;
+  diag_updater_.force_update();
+
   // generic MRPT observation object:
   if (!publish_mrpt_obs_topic_.empty())
   {
@@ -285,8 +312,6 @@ void GenericSensorNode::process_observation(const mrpt::obs::CObservation::Ptr& 
   }
 
   // Publish tf?
-  const double tNow = mrpt::Clock::nowDouble();
-
   if (publish_sensor_pose_tf_ && robot_frame_id_ != sensor_frame_id_ &&
       tNow - stamp_last_tf_publish_ >= publish_sensor_pose_tf_minimum_period_)
   {
@@ -379,6 +404,58 @@ void GenericSensorNode::process(const mrpt::obs::CObservationIMU& o)
   if (!valid) return;
 
   imu_publisher_->publish(msg);
+}
+
+void GenericSensorNode::diag_callback(diagnostic_updater::DiagnosticStatusWrapper& stat)
+{
+  const double tNow = mrpt::Clock::nowDouble();
+  const double elapsed = tNow - stamp_node_start_;
+
+  if (obs_count_ == 0)
+  {
+    if (elapsed < diag_startup_timeout_)
+    {
+      stat.summary(
+          diagnostic_msgs::msg::DiagnosticStatus::WARN,
+          "Sensor initializing, waiting for first observation...");
+    }
+    else
+    {
+      stat.summary(
+          diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+          "No observations received — sensor may not be connected.");
+    }
+  }
+  else
+  {
+    const double age = tNow - stamp_last_obs_;
+    const double stale_threshold = 3.0 / std::max(diag_expected_rate_, 0.01);
+
+    if (age > stale_threshold)
+    {
+      stat.summaryf(
+          diagnostic_msgs::msg::DiagnosticStatus::ERROR,
+          "No observations for %.1f s — sensor may have disconnected.", age);
+    }
+    else if (diag_obs_rate_ < 0.5 * diag_expected_rate_)
+    {
+      stat.summaryf(
+          diagnostic_msgs::msg::DiagnosticStatus::WARN,
+          "Rate %.2f Hz is below 50%% of expected %.2f Hz.", diag_obs_rate_, diag_expected_rate_);
+    }
+    else
+    {
+      stat.summaryf(
+          diagnostic_msgs::msg::DiagnosticStatus::OK, "OK — %.2f Hz (expected %.2f Hz).",
+          diag_obs_rate_, diag_expected_rate_);
+    }
+  }
+
+  stat.add("Observations received", obs_count_);
+  stat.add("Measured rate (Hz)", diag_obs_rate_);
+  stat.add("Expected rate (Hz)", diag_expected_rate_);
+  stat.add("Seconds since last obs", (obs_count_ > 0) ? (tNow - stamp_last_obs_) : -1.0);
+  stat.add("Startup timeout (s)", diag_startup_timeout_);
 }
 
 }  // namespace mrpt_sensors


### PR DESCRIPTION
Centralised in GenericSensorNode so every sensor package inherits it automatically without any per-package changes.

State machine:
- WARN "initialising" for the first `diag_startup_timeout` seconds (default 30 s)
- ERROR if no observation received after that timeout
- ERROR if time since last observation exceeds 3× the expected period (stale)
- WARN if smoothed rate < 50% of expected rate
- OK otherwise

New ROS 2 parameters (both in mrpt_sensorlib):
  diag_startup_timeout  [s]  (default 30.0)
  diag_expected_rate    [Hz] (default 1.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced diagnostic monitoring for sensors: publishes health to /diagnostics, reports startup state, data freshness, and observation-rate health.
  * Automatic WARN/ERROR/OK evaluation based on startup timeout, last-observation age, and measured vs expected rate.
  * New configurable parameters: startup timeout and expected observation rate.
  * Documentation added describing diagnostics usage and viewing tools.

* **Chores**
  * Added diagnostic_updater dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrpt-ros-pkg/mrpt_sensors/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->